### PR TITLE
build: `npm run build` on `prepare` hook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm --global install npm@latest
       - run: npm install
-      - run: npm run build
       - run: npm run lint
       - run: npm test
       - run: npm run release:dry-run

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
     "prerelease": "git switch main && git pull && npm install && npm run clean && npm test && npm run lint && npm run clean",
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
-    "prepare": "husky install",
-    "prepublishOnly": "npm run build",
+    "prepare": "husky install && npm run build",
     "build": "rollup index.js --file=index.cjs --format=cjs --no-esModule"
   },
   "lint-staged": {


### PR DESCRIPTION
This change aims to minimize differences in the hook scripts.