### PR TITLE
build: fix `npm run prerelease`

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
     "clean": "git clean -dx --force --exclude=node_modules --exclude=.husky",
-    "prerelease": "git switch main && git pull && npm install && npm run clean && npm test && npm run lint && npm run clean",
+    "prerelease": "git switch main && git pull && npm install && npm run clean && npm run build && npm test && npm run lint && npm run clean",
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
     "prepare": "husky install && npm run build",


### PR DESCRIPTION
```
> remark-preset-ybiquitous@0.0.3 clean
> git clean -dx --force --exclude=node_modules --exclude=.husky

Removing index.cjs
Removing package-lock.json

> remark-preset-ybiquitous@0.0.3 test
> remark .

README.md
  1:1  error  Error: Cannot parse file `package.json`
Error: Expected preset or plugin, not undefined, at `index.js`
    at Error (/Users/masafumi.koba/git/ybiquitous/remark-preset-ybiquitous/node_modules/fault/index.js:29:12)
    at onparse (/Users/masafumi.koba/git/ybiquitous/remark-preset-ybiquitous/node_modules/unified-engine/lib/find-up.js:152:13)
    at done (/Users/masafumi.koba/git/ybiquitous/remark-preset-ybiquitous/node_modules/trough/wrap.js:55:16)

✖ 1 error
```