### PR TITLE
feat: add `remark-lint-strikethrough-marker`

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ export const plugins = [
   "remark-lint-no-tabs",
   "remark-lint-no-unneeded-full-reference-image",
   "remark-lint-no-unneeded-full-reference-link",
+  ["remark-lint-strikethrough-marker", "~~"],
   "remark-lint-table-pipes",
 
   // Plugin

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "remark-lint-no-tabs": "^2.0.1",
     "remark-lint-no-unneeded-full-reference-image": "^2.0.1",
     "remark-lint-no-unneeded-full-reference-link": "^2.0.1",
+    "remark-lint-strikethrough-marker": "^1.0.0",
     "remark-lint-table-pipes": "^3.0.0",
     "remark-preset-lint-recommended": "^5.0.0",
     "remark-validate-links": "^10.0.4"


### PR DESCRIPTION
GFM requires `~~`.

See also:
- https://github.github.com/gfm/#strikethrough-extension-
- https://github.com/remarkjs/remark-lint/releases/tag/remark-lint-strikethrough-marker%401.0.0