### PR TITLE
feat!: require Node.js 12.20.0 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "license": "MIT",
   "repository": "ybiquitous/remark-preset-ybiquitous",
   "type": "module",
-  "main": "index.js",
+  "exports": "./index.js",
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "remark",
     "remark-preset",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "remark-preset",
     "markdown"
   ],
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  },
   "dependencies": {
     "remark-frontmatter": "^4.0.0",
     "remark-gfm": "^2.0.0",


### PR DESCRIPTION
This package now requires Node.js 12.20.0 or higher because of the ESM support only.
See #23

See also the guide ["Pure ESM package"](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).