### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,9 +5330,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -12704,9 +12704,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [8.5.5](https://github.com/npm/cli/releases/tag/v8.5.5).

<details open>
<summary><strong>Updated (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [minimist](https://www.npmjs.com/package/minimist/v/1.2.6) | `1.2.5` → `1.2.6` | [github](https://github.com/substack/minimist) | **[High]** Prototype Pollution in minimist ([ref](https://github.com/advisories/GHSA-xvch-5gv4-984h)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)