### PR TITLE
feat(deps): bump remark-lint-code-block-syntax from 0.3.0 to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "remark-frontmatter": "^4.0.1",
         "remark-gfm": "^3.0.1",
-        "remark-lint-code-block-syntax": "^0.3.0",
+        "remark-lint-code-block-syntax": "^0.4.0",
         "remark-lint-file-extension": "^2.1.1",
         "remark-lint-final-definition": "^3.1.1",
         "remark-lint-final-newline": "^2.1.1",
@@ -492,6 +492,231 @@
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.14.tgz",
       "integrity": "sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw==",
       "dev": true
+    },
+    "node_modules/@swc/core": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.171.tgz",
+      "integrity": "sha512-WE1Nn+LQOqMb41jDTt78REE29elW4QvbAIECpAI9wUP4SJpt9uo9ItJQ3UbXE4BECQ0JgkLz5x7l9uWUAt4YUw==",
+      "bin": {
+        "swcx": "run_swcx.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-android-arm-eabi": "1.2.171",
+        "@swc/core-android-arm64": "1.2.171",
+        "@swc/core-darwin-arm64": "1.2.171",
+        "@swc/core-darwin-x64": "1.2.171",
+        "@swc/core-freebsd-x64": "1.2.171",
+        "@swc/core-linux-arm-gnueabihf": "1.2.171",
+        "@swc/core-linux-arm64-gnu": "1.2.171",
+        "@swc/core-linux-arm64-musl": "1.2.171",
+        "@swc/core-linux-x64-gnu": "1.2.171",
+        "@swc/core-linux-x64-musl": "1.2.171",
+        "@swc/core-win32-arm64-msvc": "1.2.171",
+        "@swc/core-win32-ia32-msvc": "1.2.171",
+        "@swc/core-win32-x64-msvc": "1.2.171"
+      }
+    },
+    "node_modules/@swc/core-android-arm-eabi": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.171.tgz",
+      "integrity": "sha512-0DZBYN8PX9GPWw2fJqKfVsctAFRVgQBM2Rin5ZRyJQehzTsI0HnandvFOZAS/I3T3YsiH4b5vH/S8KwRx+eCVg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-android-arm64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.171.tgz",
+      "integrity": "sha512-9ul8XoIeXf0iHt+S2R2GedWmv/iZPrmlAj81esf/mg541kajt3kfdHD+YMKFn753iOmgTfCM+TlU82XT4nEe3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.171.tgz",
+      "integrity": "sha512-bZQLVbCRVU577LGXfhrDMqD0/cVvAFKRob3w2t/aZGY72rp9Mt56IPJcTIgah+5IeCapa4qwWwVQQVOP2DCcRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.171.tgz",
+      "integrity": "sha512-Geb3e9/o0h4VCky6dvQmHXwG+wpq0B4M0pkYySUMC3wVsqdun3rP2dF3i1FWG7F3t92sDOl3ba42JUweTtC2eA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-freebsd-x64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.171.tgz",
+      "integrity": "sha512-JSsetNvKghKTXFyAu4+vW0pVY8sDGwZSBd3foyqyx5XXEQMDVlhQEs3AVtojp7+DQrh+PmUdyCB+zS74p70nzg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.171.tgz",
+      "integrity": "sha512-ZYf5rED8Dw1dbYXolVEnexT7SYVpPJhsuKa4162Onsm/3S3xw1e+qmxJfTVdZG7jI8F2RDoZTHMLH+0y3iH98Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.171.tgz",
+      "integrity": "sha512-uteuIg77MoEwdQ0BZPGFKmbDr+V2OP1rp/Dx9sU5/O9nd1Vju/tuCycMEv8X/k0Riza6sbK6xIFVAQlrPUTZ7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.171.tgz",
+      "integrity": "sha512-d1mKKb9QaIOp3KQKvPT8pFgPvZXpYc/YHnyyI667BUboKuznB9VDpHeXk6+C/SWUIT9QdStc0fcf/Tnwni+ivA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.171.tgz",
+      "integrity": "sha512-CUNv0yNFuO4y0AnOq9Zbs44nBEuS+eLqC3gv2nEFovdUeVy71rRVelMjvdF5ZWXitHk+WjhfBznF+vP9pye3HA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.171.tgz",
+      "integrity": "sha512-orHpb/THPJOaDJkJvzGRppwOd0tmpk3ZUGTgRD6FhzYrGzESxEhXuPYNE2jlaXx9hBxu9YDRMUvJWsmLDZW3GQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.171.tgz",
+      "integrity": "sha512-zdoPPnTC5li+4ijatjZA+qyrPTQzpmOqjtQ6HAx1yLoJriGLteLfYmjplx5sFI3JrcDXzITVjaGmu3Ep4Jmhtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.171.tgz",
+      "integrity": "sha512-AmaOwrjnIQffwqrCL1MfSpG//ZbtdcCVqhY3+UtVmfKoSsSSkgWXSV++PQlJApAgRn/iwjZiR816B7zLg6535g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.171.tgz",
+      "integrity": "sha512-DrOqi27Lagn/wy2QYDOiNr0KAJX4yR0areDcli2NQ875tva5uVFgvZo5sJFsHiLU/x6yBcxVpVAbzg8a1jRUAA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -2663,18 +2888,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -6412,11 +6625,11 @@
       }
     },
     "node_modules/remark-lint-code-block-syntax": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/remark-lint-code-block-syntax/-/remark-lint-code-block-syntax-0.3.0.tgz",
-      "integrity": "sha512-ShFT1iUoR+9qvvVhMpSQ8kH0kRUttG6WHUtKN9jxuvt4EdjVoHMa+y+Ye45cWqWoRsCNeUOSaEauZBTKP4uxfQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-code-block-syntax/-/remark-lint-code-block-syntax-0.4.0.tgz",
+      "integrity": "sha512-SxovzcfEJ7B0JfFyqOQEZ/ifhKIvLrNXbIC+y4pUwDDqdO/v+WhsW1VzwKuutRoADgQicU1Fzr2eq9EgvgQwZA==",
       "dependencies": {
-        "esprima": "^4.0.1",
+        "@swc/core": "^1.2.171",
         "js-yaml": "^4.0.0",
         "unified-lint-rule": "^2.0.0",
         "unist-util-visit": "^4.0.0"
@@ -9163,6 +9376,104 @@
       "integrity": "sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw==",
       "dev": true
     },
+    "@swc/core": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.171.tgz",
+      "integrity": "sha512-WE1Nn+LQOqMb41jDTt78REE29elW4QvbAIECpAI9wUP4SJpt9uo9ItJQ3UbXE4BECQ0JgkLz5x7l9uWUAt4YUw==",
+      "requires": {
+        "@swc/core-android-arm-eabi": "1.2.171",
+        "@swc/core-android-arm64": "1.2.171",
+        "@swc/core-darwin-arm64": "1.2.171",
+        "@swc/core-darwin-x64": "1.2.171",
+        "@swc/core-freebsd-x64": "1.2.171",
+        "@swc/core-linux-arm-gnueabihf": "1.2.171",
+        "@swc/core-linux-arm64-gnu": "1.2.171",
+        "@swc/core-linux-arm64-musl": "1.2.171",
+        "@swc/core-linux-x64-gnu": "1.2.171",
+        "@swc/core-linux-x64-musl": "1.2.171",
+        "@swc/core-win32-arm64-msvc": "1.2.171",
+        "@swc/core-win32-ia32-msvc": "1.2.171",
+        "@swc/core-win32-x64-msvc": "1.2.171"
+      }
+    },
+    "@swc/core-android-arm-eabi": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.171.tgz",
+      "integrity": "sha512-0DZBYN8PX9GPWw2fJqKfVsctAFRVgQBM2Rin5ZRyJQehzTsI0HnandvFOZAS/I3T3YsiH4b5vH/S8KwRx+eCVg==",
+      "optional": true
+    },
+    "@swc/core-android-arm64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.171.tgz",
+      "integrity": "sha512-9ul8XoIeXf0iHt+S2R2GedWmv/iZPrmlAj81esf/mg541kajt3kfdHD+YMKFn753iOmgTfCM+TlU82XT4nEe3w==",
+      "optional": true
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.171.tgz",
+      "integrity": "sha512-bZQLVbCRVU577LGXfhrDMqD0/cVvAFKRob3w2t/aZGY72rp9Mt56IPJcTIgah+5IeCapa4qwWwVQQVOP2DCcRA==",
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.171.tgz",
+      "integrity": "sha512-Geb3e9/o0h4VCky6dvQmHXwG+wpq0B4M0pkYySUMC3wVsqdun3rP2dF3i1FWG7F3t92sDOl3ba42JUweTtC2eA==",
+      "optional": true
+    },
+    "@swc/core-freebsd-x64": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.171.tgz",
+      "integrity": "sha512-JSsetNvKghKTXFyAu4+vW0pVY8sDGwZSBd3foyqyx5XXEQMDVlhQEs3AVtojp7+DQrh+PmUdyCB+zS74p70nzg==",
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.171.tgz",
+      "integrity": "sha512-ZYf5rED8Dw1dbYXolVEnexT7SYVpPJhsuKa4162Onsm/3S3xw1e+qmxJfTVdZG7jI8F2RDoZTHMLH+0y3iH98Q==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.171.tgz",
+      "integrity": "sha512-uteuIg77MoEwdQ0BZPGFKmbDr+V2OP1rp/Dx9sU5/O9nd1Vju/tuCycMEv8X/k0Riza6sbK6xIFVAQlrPUTZ7g==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.171.tgz",
+      "integrity": "sha512-d1mKKb9QaIOp3KQKvPT8pFgPvZXpYc/YHnyyI667BUboKuznB9VDpHeXk6+C/SWUIT9QdStc0fcf/Tnwni+ivA==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.171.tgz",
+      "integrity": "sha512-CUNv0yNFuO4y0AnOq9Zbs44nBEuS+eLqC3gv2nEFovdUeVy71rRVelMjvdF5ZWXitHk+WjhfBznF+vP9pye3HA==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.171.tgz",
+      "integrity": "sha512-orHpb/THPJOaDJkJvzGRppwOd0tmpk3ZUGTgRD6FhzYrGzESxEhXuPYNE2jlaXx9hBxu9YDRMUvJWsmLDZW3GQ==",
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.171.tgz",
+      "integrity": "sha512-zdoPPnTC5li+4ijatjZA+qyrPTQzpmOqjtQ6HAx1yLoJriGLteLfYmjplx5sFI3JrcDXzITVjaGmu3Ep4Jmhtw==",
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.171.tgz",
+      "integrity": "sha512-AmaOwrjnIQffwqrCL1MfSpG//ZbtdcCVqhY3+UtVmfKoSsSSkgWXSV++PQlJApAgRn/iwjZiR816B7zLg6535g==",
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.2.171",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.171.tgz",
+      "integrity": "sha512-DrOqi27Lagn/wy2QYDOiNr0KAJX4yR0areDcli2NQ875tva5uVFgvZo5sJFsHiLU/x6yBcxVpVAbzg8a1jRUAA==",
+      "optional": true
+    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -10806,11 +11117,6 @@
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.3.0"
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -13446,11 +13752,11 @@
       }
     },
     "remark-lint-code-block-syntax": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/remark-lint-code-block-syntax/-/remark-lint-code-block-syntax-0.3.0.tgz",
-      "integrity": "sha512-ShFT1iUoR+9qvvVhMpSQ8kH0kRUttG6WHUtKN9jxuvt4EdjVoHMa+y+Ye45cWqWoRsCNeUOSaEauZBTKP4uxfQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-code-block-syntax/-/remark-lint-code-block-syntax-0.4.0.tgz",
+      "integrity": "sha512-SxovzcfEJ7B0JfFyqOQEZ/ifhKIvLrNXbIC+y4pUwDDqdO/v+WhsW1VzwKuutRoADgQicU1Fzr2eq9EgvgQwZA==",
       "requires": {
-        "esprima": "^4.0.1",
+        "@swc/core": "^1.2.171",
         "js-yaml": "^4.0.0",
         "unified-lint-rule": "^2.0.0",
         "unist-util-visit": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "remark-frontmatter": "^4.0.1",
     "remark-gfm": "^3.0.1",
-    "remark-lint-code-block-syntax": "^0.3.0",
+    "remark-lint-code-block-syntax": "^0.4.0",
     "remark-lint-file-extension": "^2.1.1",
     "remark-lint-final-definition": "^3.1.1",
     "remark-lint-final-newline": "^2.1.1",


### PR DESCRIPTION
BREAKING CHANGE: The JS parser used in remark-lint-code-block-syntax has changed.

https://github.com/ybiquitous/remark-lint-code-block-syntax/releases/tag/v0.4.0