### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7723,9 +7723,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
     },
     "node_modules/side-channel": {
@@ -14694,9 +14694,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
     },
     "side-channel": {


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [8.12.2](https://github.com/npm/cli/releases/tag/v8.12.2).

<details open>
<summary><strong>Updated (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [shell-quote](https://www.npmjs.com/package/shell-quote/v/1.7.3) | `1.7.2` → `1.7.3` | [github](https://github.com/substack/node-shell-quote) | **[Critical]** Improper Neutralization of Special Elements used in a Command in Shell-quote ([ref](https://github.com/advisories/GHSA-g4rg-993r-mgx7)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)