### PR TITLE
feat!: drop Node.js 16 and 18 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["16", "18", "20", "22", "24"]
+        node-version: ["20", "22", "24"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "ybiq": "^18.1.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "markdown"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "remark-frontmatter": "^5.0.0",


### PR DESCRIPTION
Both versions have reached their end of life.
Ref https://endoflife.date/nodejs